### PR TITLE
feat: Add map for constants ...

### DIFF
--- a/build_main.sh
+++ b/build_main.sh
@@ -7,7 +7,7 @@ set -xe
 SOURCE_FILE="src/main.cpp"
 
 # Output executable name
-OUTPUT_EXECUTABLE="bin/unites"
+OUTPUT_EXECUTABLE="bin/guc"
 
 # Compiler command
 CC="g++ -std=c++20"

--- a/build_test.sh
+++ b/build_test.sh
@@ -13,7 +13,7 @@ TEST_FILES="tests/test_main.cpp"
 
 # Output executable
 OUTPUT_DIR="bin"
-OUTPUT_EXECUTABLE="${OUTPUT_DIR}/unites_tests"
+OUTPUT_EXECUTABLE="${OUTPUT_DIR}/guc_tests"
 
 # Compile the test files and link with the Google Test lib
 g++ -std=c++20 -I${GTEST_INCLUDE_DIR} -L${GTEST_LIB_DIR} ${TEST_FILES} -lgtest -lgtest_main -pthread -o ${OUTPUT_EXECUTABLE}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,107 +1,179 @@
-// unites - Command-line utility for unit conversions
-// (Temporarily) named unites after the French translation of units as units is already a cmdline util.
+// guc - (GNU/General) Command-line utility for unit conversions
 #include <iostream>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <cstring>
 
+// Globally accessed maps.
+// Can I move this to a header file?
+std::unordered_map<std::string, std::vector<std::string> > categories;
+std::unordered_map<std::string, std::vector<std::string> > constants;
 
-std::unordered_map<std::string, std::vector<std::string> > conversion_categories;
-
-void initialize_conversion_category_map();  // Function to initialize the map
-void print_usage();  // Function to print program usage information
+// Function declarations.
+// To do: Move function decs and defs to a header file.
+void initialize_categories_map();
+void initialize_constants_map();
+void print_usage(void);  // Function to print program usage information
 void display_categories();
 void display_units(const std::string& category);
+void display_constants();
+void display_constant(const std::string& constant);
 void handle_arguments(int argc, char* argv[]);
 
-
-// Comment main to test
-int main(int argc, char* argv[]) {
+// Comment main when running tests.
+int main(int argc, char* argv[])
+{
     handle_arguments(argc, argv);
     return 0;
 }
 
-
-void initialize_conversion_category_map() {
-    conversion_categories["Temperature"] = { "celsius", "fahrenheit", "Kelvin" };
-    conversion_categories["Length"] = { "nanometer", "millimeter", "centimeter", "meter", "kilometer", "inch", "feet", "yard", "furlong", "mile", "league", "nautical mile" };
-    conversion_categories["Mass"] = { "milligram", "gram", "kilogram", "tonne", "ounce", "pound", "stone" };
-    conversion_categories["Volume"] = { "milliliter", "centiliter", "liter", "fluid oz.", "gallon" };
-    conversion_categories["Data"] = { "Bit", "Byte", "KiloByte", "MegaByte", "GigaByte", "TeraByte", "PetaByte" };
-    conversion_categories["Time"] = { "nanosecond", "millisecond", "second", "minute", "hour", "day", "week", "year" };
-    conversion_categories["Energy"] = { "Joule", "calorie", "Watt", "kilowatt", "BTU", "Quad", "therm", "horsepower" };
-    conversion_categories["Pressure"] = { "Pascal", "atmosphere", "torr", "psi" };
-    conversion_categories["Angle"] = { "degrees", "radians" };
+std::string to_upper(const std::string& str)
+{
+    std::string upperStr = str;
+    std::transform(upperStr.begin(), upperStr.end(), upperStr.begin(), [](unsigned char c)
+    {
+        return std::toupper(c);
+    });
+    return upperStr;
 }
 
+void initialize_categories_map()
+{
+    categories["TEMPERATURE"] = { "celsius", "fahrenheit", "Kelvin" };
+    categories["LENGTH"] = { "nanometer", "millimeter", "centimeter", "meter", "kilometer", "inch", "feet", "yard", "furlong", "mile", "league", "nautical mile" };
+    categories["MASS"] = { "milligram", "gram", "kilogram", "tonne", "ounce", "pound", "stone" };
+    categories["VOLUME"] = { "milliliter", "centiliter", "liter", "fluid oz.", "gallon" };
+    categories["DATA"] = { "Bit", "Byte", "KiloByte", "MegaByte", "GigaByte", "TeraByte", "PetaByte" };
+    categories["TIME"] = { "nanosecond", "millisecond", "second", "minute", "hour", "day", "week", "year" };
+    categories["ENERGY"] = { "Joule", "calorie", "Watt", "kilowatt", "BTU", "Quad", "therm", "horsepower" };
+    categories["PRESSURE"] = { "Pascal", "atmosphere", "torr", "psi" };
+    categories["ANGLE"] = { "degrees", "radians" };
+}
 
-void print_usage() {
-    printf("Usage: unites [OPTIONS] <source_unit> <target_unit> <value1> <value2>  ...\n");
+void initialize_constants_map()
+{
+    constants["SPEED OF LIGHT"] = { "299,792,458 meters/second", "1,079,252,848.8 kilometers/hour", "186,282.397 miles/second" };
+    constants["PI"] = { "3.14159" };
+    constants["ROOT 2"] = { "1.41421" };
+    constants["PHI"] = { "1.61803" };
+    constants["TAU"] = { "6.28318" };
+    constants["E"] = { "2.71828" };
+}
+
+void print_usage()
+{
+    printf("Usage: guc [OPTIONS] <source_unit> <target_unit> <value1> <value2>  ...\n");
     printf("Options:\n");
-    printf(" -h, --help               Display this help message and exit\n");
-    printf(" -v, --version            Display version information and exit\n");
-    printf(" --categories             Display available unit categories\n");
-    printf(" --units <category>       Display available units in the specified category\n");
+    printf(" -h,  --help                 Display this help message and exit\n");
+    printf(" -v,  --version              Display version information and exit\n");
+    printf(" -uc, --unit-categories      Display available unit categories\n");
+    printf(" -u,  --units <category>     Display available units in the specified category\n");
+    // To do: Write test for the below and the updated switches
+    printf(" -C,  --constants            Display available contants\n");
+    printf(" -C,  --constants <constant> Display the value of the specified constant\n");
 }
 
-
-void display_categories() {
+void display_categories()
+{
     std::cout << "Available unit categories:" << std::endl;
-    for (const auto& [key, _] : conversion_categories) {
+    for (const auto& [key, _] : categories)
         std::cout << " - " << key << std::endl;
-    }
 }
 
-
-void display_units(const std::string& category) {
-    if (conversion_categories.find(category) != conversion_categories.end()) {
-        std::cout << "Available units in the " << category << " category:" << std::endl;
-        for (const auto& value : conversion_categories[category]) {
+void display_units(const std::string& category)
+{
+    std::string cat = to_upper(category);
+    if (categories.find(cat) != categories.end())
+    {
+        std::cout << "Available units in the " << cat << " category:" << std::endl;
+        for (const auto& value : categories[cat])
             std::cout << " - " << value << std::endl;
-        }
-    } else {
-        std::cerr << "Unknown category: " << category << std::endl;
+    }
+    else
+    {
+        std::cout << "Unknown category: " << category << std::endl;
+
     }
 }
 
+void display_constants()
+{
+    std::cout << "Available constants:" << std::endl;
+    for (const auto& [key, _] : constants)
+        std::cout << " - " << key << std::endl;
+}
 
-void handle_arguments(int argc, char* argv[]) {
-    // Check if no arguments were provided
-    if (argc == 1) {
-        printf("No arguments provided.\n");
+void display_constant(const std::string& constant)
+{
+    std::string cons = to_upper(constant);
+    if (constants.find(cons) != constants.end())
+    {
+        std::cout << cons << ":" << std::endl;
+        for (const auto& value : constants[cons])
+            std::cout << value << std::endl;
+    }
+    else
+    {
+        std::cerr << "Unknown constant: " << constant << std::endl;
+    }
+}
+
+void handle_arguments(int argc, char* argv[])
+{
+    //                   User input validation:
+    // ------------------ Check for arguments ----------------------------
+    if (argc == 1)
+    {
+        std::cout << "No arguments provided." << std::endl;
         print_usage();
         return;
     }
-
-    // Once we pass the check above we initialise the map of conversion categories and their units.
-    // This is used in our argument checks below.
-    // Would it make sense to do this initialisation at compile time?
-    initialize_conversion_category_map();
-
-    // We use the following conditional block to check the user's arguments and either report an error
-    // or perform an action based on a legal input.
-    // Check for help option
-    if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0) {
+    // Initialise Category/Units and Constants maps accessed below.
+    // Can initialisation at compile time?
+    initialize_categories_map();
+    initialize_constants_map();
+    // ------------------ Check for help option ----------------------------
+    if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)
         print_usage();
-    } else if (strcmp(argv[1], "-v") == 0 || strcmp(argv[1], "--version") == 0) {
-        printf("Version 1.0\n");
-    } else if (strcmp(argv[1], "--categories") == 0) {
-        if (argc == 2) {
+    // ------------------ Check for version option -------------------------
+    else if (strcmp(argv[1], "-v") == 0 || strcmp(argv[1], "--version") == 0)
+        std::cout << "Version 1.0\n" << std::endl;
+    // ------------------ Check for version option -------------------------
+    else if (strcmp(argv[1], "-uc") == 0 || strcmp(argv[1], "--unit-categories") == 0)
+    {
+        if (argc == 2)
             display_categories();
-        } else {
-            // Communicate bad option for any argument after --categories
-            printf("Unknown option: %s\n", argv[2]);
-        }
-    } else if (strcmp(argv[1], "--units") == 0 && argc > 2) {
-        display_units(argv[2]);
-        if (argc > 3) {
-            // Communicate bad option for any argument after --units <category>
-            printf("Unknown option: %s\n", argv[3]);
-        }
-    } else {
-        // Communicate general incorrect usage
-        printf("Unknown or incomplete option: %s\n", argv[1]);
+        else
+            std::cout << "Unknown option: " << argv[2] << std::endl;
+    }
+    // ---------------- Check units + unit option --------------------------
+    else if ((strcmp(argv[1], "-u") == 0 || strcmp(argv[1], "--units") == 0) && argc > 2)
+    {
+        if (argc == 3)
+            display_units(argv[2]);
+        else
+            std::cout << "Unknown option: " << argv[3] << std::endl;
+    }
+    // ---------------- Check constants + CONSTANT option ------------------
+    else if ((strcmp(argv[1], "-C") == 0 || strcmp(argv[1], "--constants") == 0) && argc > 2)
+    {
+        if (argc == 3)
+            display_constant(argv[2]);
+        else
+            std::cout << "Unknown option: " << argv[3] << std::endl;
+    }
+    // ---------------- Check constants option ----------------------------
+    // Note: This block has to match after constants + CONSTANT.
+    else if (strcmp(argv[1], "-C") == 0 || strcmp(argv[1], "--constants") == 0)
+    {
+        if (argc == 2)
+            display_constants();
+        else
+            std::cout << "Unknown option: " << argv[2] << std::endl;
+    }
+    else
+    {
+        std::cout << "Unknown or incomplete option: " << argv[1] << std::endl;
         print_usage();
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@ std::unordered_map<std::string, std::vector<std::string> > constants;
 
 // Function declarations.
 // To do: Move function decs and defs to a header file.
+std::string to_upper(const std::string& str);
 void initialize_categories_map();
 void initialize_constants_map();
 void print_usage(void);  // Function to print program usage information
@@ -114,7 +115,7 @@ void display_constant(const std::string& constant)
     }
     else
     {
-        std::cerr << "Unknown constant: " << constant << std::endl;
+        std::cout << "Unknown constant: " << constant << std::endl;
     }
 }
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,17 +1,20 @@
-// tests/test_main.cpp
+// test_main.cpp: Contains all the tests for the unit converter application
+#include <chrono>
 #include <string>
 #include <vector>
-#include <cstring>
 
+// Google test suite
 #include <gtest/gtest.h>
 
 // Include the functions you want to test
 #include "../src/main.cpp"
 
 // Helper function to convert a vector of strings to an array of C-strings
-std::vector<char*> create_argv(const std::vector<std::string>& args) {
+std::vector<char*> create_argv(const std::vector<std::string>& args)
+{
     std::vector<char*> argv;
-    for (const auto& arg : args) {
+    for (const auto& arg : args)
+    {
         char* cstr = new char[arg.size() + 1];
         std::strcpy(cstr, arg.c_str());
         argv.push_back(cstr);
@@ -20,247 +23,267 @@ std::vector<char*> create_argv(const std::vector<std::string>& args) {
     return argv;
 }
 
-// The tests for the following arguments below
-// unites --help
-// unites --version
-// unites --categories Temperature
-// unites --categories Length
-// unites --categories Energy
-// unites --units Energy
-// unites --ca b
-// unites --units
-// unites --categories b
-// unites --units Length
-// unites --categories
-// unites --units Data
-// unites
+// To do: I have a lot more cases to write, how do I manage the test arguments list below?
+// ---------------------------------------------------------------------------------------
+// guc --help
+// guc --version
+// guc --categories Temperature
+// guc --categories Length
+// guc --categories Energy
+// guc --units Energy
+// guc --ca b
+// guc --units
+// guc --categories b
+// guc --units Length
+// guc --categories
+// guc --units Data
+// guc
+// guc --units Energy b
+// ---------------------------------------------------------------------------------------
 
-TEST(UnitesTest, HelpOption) {
-    std::vector<std::string> args = {"unites", "--help"};
+TEST(UnitesTest, HelpOption)
+{
+    std::vector<std::string> args = {"guc", "--help"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
-    EXPECT_TRUE(output.find("Usage: unites") != std::string::npos);
+    EXPECT_TRUE(output.find("Usage: guc") != std::string::npos);
 }
 
-TEST(UnitesTest, VersionOption) {
-    std::vector<std::string> args = {"unites", "--version"};
+TEST(UnitesTest, VersionOption)
+{
+    std::vector<std::string> args = {"guc", "--version"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
     EXPECT_TRUE(output.find("Version 1.0") != std::string::npos);
 }
 
-TEST(UnitesTest, CategoriesOption) {
-    std::vector<std::string> args = {"unites", "--categories"};
+TEST(UnitesTest, CategoriesOption)
+{
+    std::vector<std::string> args = {"guc", "--unit-categories"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
     EXPECT_TRUE(output.find("Available unit categories:") != std::string::npos);
 }
 
-TEST(UnitesTest, UnitsOption) {
-    std::vector<std::string> args = {"unites", "--units", "Length"};
+TEST(UnitesTest, UnitsOption)
+{
+    std::vector<std::string> args = {"guc", "--units", "Length"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
-    EXPECT_TRUE(output.find("Available units in the Length category:") != std::string::npos);
+    EXPECT_TRUE(output.find("Available units in the LENGTH category:") != std::string::npos);
 }
 
-TEST(UnitesTest, CategoriesTemperatureOption) {
-    std::vector<std::string> args = {"unites", "--categories", "Temperature"};
+TEST(UnitesTest, CategoriesTemperatureOption)
+{
+    std::vector<std::string> args = {"guc", "--unit-categories", "Temperature"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
     EXPECT_TRUE(output.find("Unknown option: Temperature") != std::string::npos);
 }
 
-TEST(UnitesTest, CategoriesLengthOption) {
-    std::vector<std::string> args = {"unites", "--categories", "Length"};
+TEST(UnitesTest, CategoriesLengthOption)
+{
+    std::vector<std::string> args = {"guc", "--unit-categories", "Length"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
     EXPECT_TRUE(output.find("Unknown option: Length") != std::string::npos);
 }
 
-TEST(UnitesTest, CategoriesEnergyOption) {
-    std::vector<std::string> args = {"unites", "--categories", "Energy"};
+TEST(UnitesTest, CategoriesEnergyOption)
+{
+    std::vector<std::string> args = {"guc", "--unit-categories", "Energy"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
     EXPECT_TRUE(output.find("Unknown option: Energy") != std::string::npos);
 }
 
-TEST(UnitesTest, UnitsEnergyOption) {
-    std::vector<std::string> args = {"unites", "--units", "Energy"};
+TEST(UnitesTest, UnitsEnergyOption)
+{
+    std::vector<std::string> args = {"guc", "--units", "Energy"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
-    EXPECT_TRUE(output.find("Available units in the Energy category:") != std::string::npos);
+    EXPECT_TRUE(output.find("Available units in the ENERGY category:") != std::string::npos);
 }
 
-TEST(UnitesTest, CaBOption) {
-    std::vector<std::string> args = {"unites", "--ca", "b"};
+TEST(UnitesTest, UnitsEnergyExtraOption) {
+    std::vector<std::string> args = {"guc", "--units", "Energy", "b"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
-
-    EXPECT_TRUE(output.find("Unknown or incomplete option: --ca") != std::string::npos);
-}
-
-TEST(UnitesTest, UnitsWithoutCategory) {
-    std::vector<std::string> args = {"unites", "--units"};
-    auto argv = create_argv(args);
-
-    testing::internal::CaptureStdout();
-    handle_arguments(args.size(), argv.data());
-    std::string output = testing::internal::GetCapturedStdout();
-
-    for (char* arg : argv) {
-        delete[] arg;
-    }
-
-    EXPECT_TRUE(output.find("Unknown or incomplete option: --units") != std::string::npos);
-}
-
-TEST(UnitesTest, CategoriesBOption) {
-    std::vector<std::string> args = {"unites", "--categories", "b"};
-    auto argv = create_argv(args);
-
-    testing::internal::CaptureStdout();
-    handle_arguments(args.size(), argv.data());
-    std::string output = testing::internal::GetCapturedStdout();
-
-    for (char* arg : argv) {
-        delete[] arg;
-    }
 
     EXPECT_TRUE(output.find("Unknown option: b") != std::string::npos);
 }
 
-TEST(UnitesTest, UnitsLengthOption) {
-    std::vector<std::string> args = {"unites", "--units", "Length"};
+TEST(UnitesTest, CaBOption)
+{
+    std::vector<std::string> args = {"guc", "--ca", "b"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
-    EXPECT_TRUE(output.find("Available units in the Length category:") != std::string::npos);
+    EXPECT_TRUE(output.find("Unknown or incomplete option: --ca") != std::string::npos);
+}
+
+TEST(UnitesTest, UnitsWithoutCategory)
+{
+    std::vector<std::string> args = {"guc", "--units"};
+    auto argv = create_argv(args);
+
+    testing::internal::CaptureStdout();
+    handle_arguments(args.size(), argv.data());
+    std::string output = testing::internal::GetCapturedStdout();
+
+    for (char* arg : argv)
+        delete[] arg;
+
+    EXPECT_TRUE(output.find("Unknown or incomplete option: --units") != std::string::npos);
+}
+
+TEST(UnitesTest, CategoriesBOption)
+{
+    std::vector<std::string> args = {"guc", "--unit-categories", "b"};
+    auto argv = create_argv(args);
+
+    testing::internal::CaptureStdout();
+    handle_arguments(args.size(), argv.data());
+    std::string output = testing::internal::GetCapturedStdout();
+
+    for (char* arg : argv)
+        delete[] arg;
+
+    EXPECT_TRUE(output.find("Unknown option: b") != std::string::npos);
+}
+
+TEST(UnitesTest, UnitsLengthOption)
+{
+    std::vector<std::string> args = {"guc", "--units", "Length"};
+    auto argv = create_argv(args);
+
+    testing::internal::CaptureStdout();
+    handle_arguments(args.size(), argv.data());
+    std::string output = testing::internal::GetCapturedStdout();
+
+    for (char* arg : argv)
+        delete[] arg;
+
+    EXPECT_TRUE(output.find("Available units in the LENGTH category:") != std::string::npos);
 }
 
 TEST(UnitesTest, CategoriesWithoutArgument) {
-    std::vector<std::string> args = {"unites", "--categories"};
+    std::vector<std::string> args = {"guc", "--unit-categories"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
     EXPECT_TRUE(output.find("Available unit categories:") != std::string::npos);
 }
 
-TEST(UnitesTest, UnitsDataOption) {
-    std::vector<std::string> args = {"unites", "--units", "Data"};
+TEST(UnitesTest, UnitsDataOption)
+{
+    std::vector<std::string> args = {"guc", "--units", "Data"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
-    EXPECT_TRUE(output.find("Available units in the Data category:") != std::string::npos);
+    EXPECT_TRUE(output.find("Available units in the DATA category:") != std::string::npos);
 }
 
-TEST(UnitesTest, NoArguments) {
-    std::vector<std::string> args = {"unites"};
+TEST(UnitesTest, NoArguments)
+{
+    std::vector<std::string> args = {"guc"};
     auto argv = create_argv(args);
 
     testing::internal::CaptureStdout();
     handle_arguments(args.size(), argv.data());
     std::string output = testing::internal::GetCapturedStdout();
 
-    for (char* arg : argv) {
+    for (char* arg : argv)
         delete[] arg;
-    }
 
-    EXPECT_TRUE(output.find("No arguments provided.\nUsage: unites") != std::string::npos);
+    EXPECT_TRUE(output.find("No arguments provided.\nUsage: guc") != std::string::npos);
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
+    // Log-out test runtime
+    std::cout << "\033[36mTest runtime: " <<std::chrono::system_clock::now() << "\033[0m" << std::endl;
+
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
 Additional
    1. Add initialize_constants_map()
    2. Add display_constants()
    3. Add display_constant()
    4. Update handle_arguments() to accept arguments for constants
    5. Add to_upper() to make arguments to switches case-insensitive
    6. Update print_usage() for constants
    7. Update print_usage() to accept switch aliases for categories/units
    8. Change keys in categories map to upper case
    9. Update test_main.cpp to accomadate changes in main.cpp for existing
       tests
    10. Removed unnecessary library imports from main.cpp and test_main.cpp
    11. Update code style - trying lined up braces
    12. Add to dos and reflections to main.cpp and test_main.cpp